### PR TITLE
Output GPX routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ function togpx( geojson, options ) {
     case "LineString":
     case "MultiLineString":
       var coords = f.geometry.coordinates;
-      var times = f.properties ? f.properties.times : null;
+      var times = f.properties ? f.properties.times || f.properties.coordTimes : null;
       if (f.geometry.type == "LineString") coords = [coords];
       o = {
         "name": options.featureTitle(f.properties),
@@ -135,7 +135,7 @@ function togpx( geojson, options ) {
       add_feature_link(o,f);
       o.trkseg = [];
       var coords = f.geometry.coordinates;
-      var times = f.properties ? f.properties.times : null;
+      var times = f.properties ? f.properties.times || f.properties.coordTimes : null;
       if (f.geometry.type == "Polygon") coords = [coords];
       coords.forEach(function(poly) {
         poly.forEach(function(ring) {

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ function togpx( geojson, options ) {
     metadata: undefined,
     featureTitle: get_feature_title,
     featureDescription: get_feature_description,
-    featureLink: undefined
+    featureLink: undefined,
+    featureCoordTimes: get_feature_coord_times,
   }, options || {});
 
   function get_feature_title(props) {
@@ -48,6 +49,9 @@ function togpx( geojson, options ) {
     }
     return res.substr(0,res.length-1);
   }
+  function get_feature_coord_times(props) {
+    return props.times || props.coordTimes || null;
+  }
   function add_feature_link(o, f) {
     if (options.featureLink)
       o.link = { "@href": options.featureLink(f.properties) }
@@ -74,6 +78,8 @@ function togpx( geojson, options ) {
   else
     features = [{type:"Feature", properties: {}, geometry: geojson}];
   features.forEach(function mapFeature(f) {
+    if (!f.hasOwnProperty('properties'))
+      f.properties = {};
     switch (f.geometry.type) {
     // POIs
     case "Point":
@@ -98,7 +104,7 @@ function togpx( geojson, options ) {
     case "LineString":
     case "MultiLineString":
       var coords = f.geometry.coordinates;
-      var times = f.properties ? f.properties.times || f.properties.coordTimes : null;
+      var times = options.featureCoordTimes(f.properties);
       if (f.geometry.type == "LineString") coords = [coords];
       o = {
         "name": options.featureTitle(f.properties),
@@ -135,7 +141,7 @@ function togpx( geojson, options ) {
       add_feature_link(o,f);
       o.trkseg = [];
       var coords = f.geometry.coordinates;
-      var times = f.properties ? f.properties.times || f.properties.coordTimes : null;
+      var times = options.featureCoordTimes(f.properties);
       if (f.geometry.type == "Polygon") coords = [coords];
       coords.forEach(function(poly) {
         poly.forEach(function(ring) {

--- a/test/test.js
+++ b/test/test.js
@@ -495,6 +495,33 @@ describe("properties", function () {
     expect(pts[1].getElementsByTagName("time")[0].textContent).to.equal("2014-06-23T20:29:11Z");
   });
 
+  it('Time (coordTimes)', function() {
+    var geojson, result;
+    geojson = {
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        properties: {
+          coordTimes: [
+            "2014-06-23T20:29:08Z",
+            "2014-06-23T20:29:11Z",
+          ]
+        },
+        geometry: {
+          type: "LineString",
+          coordinates: [[1.0,2.0],[3.0,4.0]]
+        }
+      }]
+    };
+    result = togpx(geojson);
+    result = (new DOMParser()).parseFromString(result, 'text/xml');
+    var pts = result.getElementsByTagName("trkpt");
+    expect(pts[0].getElementsByTagName("time")).to.have.length(1);
+    expect(pts[0].getElementsByTagName("time")[0].textContent).to.equal("2014-06-23T20:29:08Z");
+    expect(pts[1].getElementsByTagName("time")).to.have.length(1);
+    expect(pts[1].getElementsByTagName("time")[0].textContent).to.equal("2014-06-23T20:29:11Z");
+  });
+
 });
 
 describe("elevation", function () {

--- a/test/test.js
+++ b/test/test.js
@@ -495,25 +495,24 @@ describe("properties", function () {
     expect(pts[1].getElementsByTagName("time")[0].textContent).to.equal("2014-06-23T20:29:11Z");
   });
 
-  it('Time (coordTimes)', function() {
+  it('Time (custom)', function() {
     var geojson, result;
     geojson = {
       type: "FeatureCollection",
       features: [{
         type: "Feature",
-        properties: {
-          coordTimes: [
-            "2014-06-23T20:29:08Z",
-            "2014-06-23T20:29:11Z",
-          ]
-        },
         geometry: {
           type: "LineString",
           coordinates: [[1.0,2.0],[3.0,4.0]]
         }
       }]
     };
-    result = togpx(geojson);
+    result = togpx(geojson, {featureCoordTimes: function(props) {
+      return [
+        "2014-06-23T20:29:08Z",
+        "2014-06-23T20:29:11Z",
+      ];
+    }});
     result = (new DOMParser()).parseFromString(result, 'text/xml');
     var pts = result.getElementsByTagName("trkpt");
     expect(pts[0].getElementsByTagName("time")).to.have.length(1);

--- a/test/test.js
+++ b/test/test.js
@@ -340,6 +340,237 @@ describe("geometries", function () {
   });
 });
 
+describe("routes", function () {
+
+
+  it('LineString (route)', function() {
+    var geojson, options, result;
+    geojson = {
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "LineString",
+          coordinates: [[1.0,2.0],[3.0,4.0]]
+        }
+      }]
+    };
+    options = {
+      "gpx.rte": true,
+      "gpx.trk": false,
+    }
+    result = togpx(geojson, options);
+    result = (new DOMParser()).parseFromString(result, 'text/xml');
+    expect(result.getElementsByTagName("wpt")).to.have.length(0);
+    expect(result.getElementsByTagName("trk")).to.have.length(0);
+    expect(result.getElementsByTagName("rte")).to.have.length(1);
+    var rte = result.getElementsByTagName("rte")[0];
+    var rtepts = rte.getElementsByTagName("rtept");
+    expect(rtepts).to.have.length(2);
+    expect(rtepts[0].getAttribute("lat")).to.eql(2.0);
+    expect(rtepts[0].getAttribute("lon")).to.eql(1.0);
+    expect(rtepts[1].getAttribute("lat")).to.eql(4.0);
+    expect(rtepts[1].getAttribute("lon")).to.eql(3.0);
+  });
+
+  it('MultiLineString (route)', function() {
+    var geojson, options, result;
+    geojson = {
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "MultiLineString",
+          coordinates: [[[1.0,2.0],[3.0,4.0]],[[1.0,1.0],[2.0,2.0]]]
+        }
+      }]
+    };
+    options = {
+      "gpx.rte": true,
+      "gpx.trk": false,
+    }
+    result = togpx(geojson, options);
+    result = (new DOMParser()).parseFromString(result, 'text/xml');
+    expect(result.getElementsByTagName("wpt")).to.have.length(0);
+    expect(result.getElementsByTagName("trk")).to.have.length(0);
+    expect(result.getElementsByTagName("rte")).to.have.length(2);
+    var rtes = result.getElementsByTagName("rte");
+    var rtepts = rtes[0].getElementsByTagName("rtept");
+    expect(rtepts).to.have.length(2);
+    expect(rtepts[0].getAttribute("lat")).to.eql(2.0);
+    expect(rtepts[0].getAttribute("lon")).to.eql(1.0);
+    expect(rtepts[1].getAttribute("lat")).to.eql(4.0);
+    expect(rtepts[1].getAttribute("lon")).to.eql(3.0);
+    rtepts = rtes[1].getElementsByTagName("rtept");
+    expect(rtepts).to.have.length(2);
+    expect(rtepts[0].getAttribute("lat")).to.eql(1.0);
+    expect(rtepts[0].getAttribute("lon")).to.eql(1.0);
+    expect(rtepts[1].getAttribute("lat")).to.eql(2.0);
+    expect(rtepts[1].getAttribute("lon")).to.eql(2.0);
+  });
+
+  it('Polygon (no holes) (route)', function() {
+    var geojson, options, result;
+    geojson = {
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "Polygon",
+          coordinates: [
+            [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ]
+          ]
+        }
+      }]
+    };
+    options = {
+      "gpx.rte": true,
+      "gpx.trk": false,
+    }
+    result = togpx(geojson, options);
+    result = (new DOMParser()).parseFromString(result, 'text/xml');
+    expect(result.getElementsByTagName("wpt")).to.have.length(0);
+    expect(result.getElementsByTagName("trk")).to.have.length(0);
+    expect(result.getElementsByTagName("rte")).to.have.length(1);
+    var rtes = result.getElementsByTagName("rte");
+    expect(rtes).to.have.length(1);
+    var rtepts = rtes[0].getElementsByTagName("rtept");
+    expect(rtepts).to.have.length(5);
+    expect(rtepts[0].getAttribute("lat")).to.eql(0.0);
+    expect(rtepts[0].getAttribute("lon")).to.eql(100.0);
+    // skip remaining points, should be ok
+  });
+
+  it('Polygon (with hole)', function() {
+    var geojson, options, result;
+    geojson = {
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "Polygon",
+          coordinates: [
+            [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ],
+            [ [100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2] ]
+          ]
+        }
+      }]
+    };
+    options = {
+      "gpx.rte": true,
+      "gpx.trk": false,
+    }
+    result = togpx(geojson, options);
+    result = (new DOMParser()).parseFromString(result, 'text/xml');
+    expect(result.getElementsByTagName("wpt")).to.have.length(0);
+    expect(result.getElementsByTagName("trk")).to.have.length(0);
+    expect(result.getElementsByTagName("rte")).to.have.length(2);
+    var rtes = result.getElementsByTagName("rte");
+    expect(rtes).to.have.length(2);
+    var rtepts = rtes[0].getElementsByTagName("rtept");
+    expect(rtepts).to.have.length(5);
+    expect(rtepts[0].getAttribute("lat")).to.eql(0.0);
+    expect(rtepts[0].getAttribute("lon")).to.eql(100.0);
+    // skip remaining points, should be ok
+    rtepts = rtes[1].getElementsByTagName("rtept");
+    expect(rtepts).to.have.length(5);
+    expect(rtepts[0].getAttribute("lat")).to.eql(0.2);
+    expect(rtepts[0].getAttribute("lon")).to.eql(100.2);
+    // skip remaining points, should be ok
+  });
+
+  it('MultiPolygon', function() {
+    var geojson, options, result;
+    geojson = {
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "MultiPolygon",
+          coordinates: [
+            [[[102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0]]],
+            [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]],
+             [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]]
+          ]
+        }
+      }]
+    };
+    options = {
+      "gpx.rte": true,
+      "gpx.trk": false,
+    }
+    result = togpx(geojson, options);
+    result = (new DOMParser()).parseFromString(result, 'text/xml');
+    expect(result.getElementsByTagName("wpt")).to.have.length(0);
+    expect(result.getElementsByTagName("trk")).to.have.length(0);
+    expect(result.getElementsByTagName("rte")).to.have.length(3);
+    var rtes = result.getElementsByTagName("rte");
+    expect(rtes).to.have.length(3);
+    var rtepts = rtes[0].getElementsByTagName("rtept");
+    expect(rtepts).to.have.length(5);
+    expect(rtepts[0].getAttribute("lat")).to.eql(2.0);
+    expect(rtepts[0].getAttribute("lon")).to.eql(102.0);
+    // skip remaining points, should be ok
+    rtepts = rtes[1].getElementsByTagName("rtept");
+    expect(rtepts).to.have.length(5);
+    expect(rtepts[0].getAttribute("lat")).to.eql(0.0);
+    expect(rtepts[0].getAttribute("lon")).to.eql(100.0);
+    // skip remaining points, should be ok
+    rtepts = rtes[2].getElementsByTagName("rtept");
+    expect(rtepts).to.have.length(5);
+    expect(rtepts[0].getAttribute("lat")).to.eql(0.2);
+    expect(rtepts[0].getAttribute("lon")).to.eql(100.2);
+    // skip remaining points, should be ok
+  });
+
+  it('GeometryCollection', function() {
+    var geojson, options, result;
+    geojson = {
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "GeometryCollection",
+          geometries: [
+            { "type": "Point",
+              "coordinates": [100.0, 0.0]
+              },
+            { "type": "LineString",
+              "coordinates": [ [101.0, 0.0], [102.0, 1.0] ]
+              }
+          ]
+        }
+      }]
+    };
+    options = {
+      "gpx.rte": true,
+      "gpx.trk": false,
+    }
+    result = togpx(geojson, options);
+    result = (new DOMParser()).parseFromString(result, 'text/xml');
+    expect(result.getElementsByTagName("wpt")).to.have.length(1);
+    expect(result.getElementsByTagName("trk")).to.have.length(0);
+    expect(result.getElementsByTagName("rte")).to.have.length(1);
+    var wpt = result.getElementsByTagName("wpt")[0];
+    expect(wpt.getAttribute("lat")).to.eql(0.0);
+    expect(wpt.getAttribute("lon")).to.eql(100.0);
+    var rtes = result.getElementsByTagName("rte");
+    expect(rtes).to.have.length(1);
+    var rtepts = rtes[0].getElementsByTagName("rtept");
+    expect(rtepts).to.have.length(2);
+    expect(rtepts[0].getAttribute("lat")).to.eql(0.0);
+    expect(rtepts[0].getAttribute("lon")).to.eql(101.0);
+    expect(rtepts[1].getAttribute("lat")).to.eql(1.0);
+    expect(rtepts[1].getAttribute("lon")).to.eql(102.0);
+  });
+})
+
 describe("properties", function () {
 
   it('Name', function() {
@@ -717,6 +948,41 @@ describe("options", function () {
     var wpt = result.getElementsByTagName("wpt")[0];
     expect(wpt.getElementsByTagName("link")).to.have.length(1);
     expect(wpt.getElementsByTagName("link")[0].getAttribute("href")).to.equal("http://example.com");
+  });
+
+  it('gpx.{wpt|trk|rte}', function() {
+    var geojson, result;
+    geojson = {
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "GeometryCollection",
+          geometries: [
+            { "type": "MultiPoint",
+              "coordinates": [ [31.0, 0.0], [32.0, 0.0] ]
+              },
+            { "type": "MultiLineString",
+              "coordinates": [ [[101.0, 0.0], [102.0, 1.0]], [[103.0, 0.0], [104.0, 1.0]] ]
+              }
+          ]
+        }
+      }]
+    };
+
+    result = togpx(geojson, {
+      "gpx.wpt": true,
+      "gpx.rte": true,
+      "gpx.trk": true,
+    });
+    result = (new DOMParser()).parseFromString(result, 'text/xml');
+    expect(result.getElementsByTagName("wpt")).to.have.length(2);
+    expect(result.getElementsByTagName("trk")).to.have.length(1);
+    expect(result.getElementsByTagName("rte")).to.have.length(2);
+    var trk = result.getElementsByTagName("trk")[0];
+    var trksegs = trk.getElementsByTagName("trkseg");
+    expect(trksegs).to.have.length(2);
   });
 
 });


### PR DESCRIPTION
Instead of tracks `<trk>` also routes `<rte>` could be returned if the option `{"gpx.rte": true}` is provided. Evenmore you can specify to disable the `<trk>` or `<wpt>` output by setting `{"gpx.trk": false, "gpx.wpt": false}`. 

Where MultiString, Polygon, MultiPolygon, and GeometryCollection will return a single track consisting of possibly multiple track segments, in the case of routes just multiple routes are returned due the lack of segments in that format.

Example:
```
togpx({
  type: "Feature",
  properties: {},
  geometry: {
    type: "GeometryCollection",
    geometries: [
      { "type": "MultiPoint",
        "coordinates": [ [31.0, 0.0], [32.0, 0.0] ]
      },
      { "type": "MultiLineString",
        "coordinates": [ [[101.0, 0.0], [102.0, 1.0]], [[103.0, 0.0], [104.0, 1.0]] ]
      }
    ]
  }
}, {"gpx.rte": true})
```

Output:
```
<gpx creator="togpx" version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">

  <wpt lat="0" lon="31">
    <name/>
    <desc/>
  </wpt>

  <wpt lat="0" lon="32">
    <name/>
    <desc/>
  </wpt>

  <trk>
    <name/>
    <desc/>
    <trkseg>
      <trkpt lat="0" lon="101"/>
      <trkpt lat="1" lon="102"/>
    </trkseg>
    <trkseg>
      <trkpt lat="0" lon="103"/>
      <trkpt lat="1" lon="104"/>
    </trkseg>
  </trk>

  <rte>
    <name/>
    <desc/>
    <rtept lat="0" lon="101"/>
    <rtept lat="1" lon="102"/>
  </rte>

  <rte>
    <name/>
    <desc/>
    <rtept lat="0" lon="103"/>
    <rtept lat="1" lon="104"/>
  </rte>

</gpx>
```