### PR TITLE
Support all string properties of wptType tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ The conversion from GeoJSON to GPX is (by definition) lossy, because not every G
 * Points are converted to [Waypoints](http://www.topografix.com/gpx/1/1/#type_wptType).
 * Lines are converted to [Tracks](http://www.topografix.com/gpx/1/1/#type_trkType).
 * (Multi)Polygons are represented as a [Track](http://www.topografix.com/gpx/1/1/#type_trkType) of their outline(s).
-* By default, the `name` tag of GPX elements will be determined by a simple heuristic that searches for the following GeoJSON properties to construct a meaningful title: `name`, `ref`, `id`
-* By default, the `desc` tag of GPX elements will be constructed by concatenating all respective GeoJSON properties.
-* Elevation is included in the output if the GeoJSON coordinates contain altitude as a third value (`[lon, lat, altitude]`)
+* Elevation is included in the output if the GeoJSON coordinates contain altitude as a third value (`[lon, lat, altitude]`).
 * Timestamps are included in the GPX output if the GeoJSON has a `times` or `coordTimes` property that is an array of UTC ISO 8601 timestamp strings. See the `featureCoordTimes` option for customizing this behaviour.
+* Properties of a point that match the name of a supported GPX waypoint tag are included in the output. For waypoints, the `featureTitle` and `featureDescription` callbacks are only used as fallbacks.
+* By default, the `name` tag of GPX elements will be determined by a simple heuristic that searches for the following GeoJSON properties to construct a meaningful title: `name`, `ref`, `id`.
+* By default, the `desc` tag of GPX elements will be constructed by concatenating all respective GeoJSON properties.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ API
   * `metadata`: An object containing [metadata](http://www.topografix.com/gpx/1/1/#type_metadataType) about the to be converted dataset. Will be included in the GPX in the `<metadata>` tag. Usefull for providing information like `copyright`, `time`, `desc`, etc.
   * `featureTitle`: Defines a callback that is used to construct a title (`<name>`) for a given GeoJSON feature. The callback is called with the GeoJSON feature's `properties` object.
   * `featureDescription`: Defines a callback that is used to construct a description (`<desc>`) for a given GeoJSON feature. The callback is called with the GeoJSON feature's `properties` object.
-  * `featureLink`: Defines a callback that is used to construct an URL (`<link>`) for a given GeoJSON feature. The callback is called with the GeoJSON feature's `properties` object.
+  * `featureLink`: Defines a callback that is used to construct a URL (`<link>`) for a given GeoJSON feature in the absence of a `links` property that contains an array of link objects (containing a `href` and, possibly, `text` and `type`). The callback is called with the GeoJSON feature's `properties` object.
   * `featureCoordTimes`: Defines a callback that is called for each feature to determine timestamps of each coordinate. Gets called with the current feature as a parameter, must return an array of UTC ISO 8601 timestamp strings for each coordinate of the feature. Alternatively. this option can be a string, in which case the corresponding feature property is used to read the times array.
 
 The result is a string of GPX XML.

--- a/index.js
+++ b/index.js
@@ -36,13 +36,7 @@ function togpx( geojson, options ) {
       if (tags_title !== "")
         return tags_title;
     }
-    if (props.name)
-      return props.name;
-    if (props.ref)
-      return props.ref;
-    if (props.id)
-      return props.id;
-    return "";
+    return props.name || props.ref || props.id || "";
   }
   function get_feature_description(props) {
     // constructs a description for a given feature
@@ -63,9 +57,23 @@ function togpx( geojson, options ) {
     if (!feature.properties) return null;
     return feature.properties.times || feature.properties.coordTimes || null;
   }
-  function add_feature_link(o, f) {
+  function add_feature_link(o, props) {
     if (options.featureLink)
-      o.link = { "@href": options.featureLink(f.properties) }
+      o.link = { "@href": options.featureLink(props) };
+  }
+  function make_wpt(coord, time, props) {
+    var pt = {
+      "@lat": coord[1],
+      "@lon": coord[0]
+    };
+    if (coord[2] !== undefined) pt.ele = coord[2];
+    if (time) pt.time = time;
+    if (props !== undefined) {
+      pt.name = options.featureTitle(props);
+      pt.desc = options.featureDescription(props);
+      add_feature_link(pt, props);
+    }
+    return pt;
   }
   // make gpx object
   var gpx = {"gpx": {
@@ -98,18 +106,8 @@ function togpx( geojson, options ) {
     case "MultiPoint":
       var coords = f.geometry.coordinates;
       if (f.geometry.type == "Point") coords = [coords];
-      coords.forEach(function (coordinates) {
-        o = {
-          "@lat": coordinates[1],
-          "@lon": coordinates[0],
-          "name": options.featureTitle(f.properties),
-          "desc": options.featureDescription(f.properties)
-        };
-        if (coordinates[2] !== undefined) {
-          o.ele = coordinates[2];
-        }
-        add_feature_link(o,f);
-        gpx.gpx.wpt.push(o);
+      coords.forEach(function(c) {
+        gpx.gpx.wpt.push(make_wpt(c, undefined, f.properties));
       });
       break;
     // LineStrings
@@ -118,26 +116,16 @@ function togpx( geojson, options ) {
       var coords = f.geometry.coordinates;
       var times = options.featureCoordTimes(f);
       if (f.geometry.type == "LineString") coords = [coords];
-      o = {
+      var o = {
         "name": options.featureTitle(f.properties),
         "desc": options.featureDescription(f.properties)
       };
-      add_feature_link(o,f);
+      add_feature_link(o, f.properties);
       o.trkseg = [];
       coords.forEach(function(coordinates) {
         var seg = {trkpt: []};
         coordinates.forEach(function(c, i) {
-          var o = {
-            "@lat": c[1],
-            "@lon":c[0]
-          };
-          if (c[2] !== undefined) {
-            o.ele = c[2];
-          }
-          if (times && times[i]) {
-            o.time = times[i];
-          }
-          seg.trkpt.push(o);
+          seg.trkpt.push(make_wpt(c, times && times[i]));
         });
         o.trkseg.push(seg);
       });
@@ -146,11 +134,11 @@ function togpx( geojson, options ) {
     // Polygons / Multipolygons
     case "Polygon":
     case "MultiPolygon":
-      o = {
+      var o = {
         "name": options.featureTitle(f.properties),
         "desc": options.featureDescription(f.properties)
       };
-      add_feature_link(o,f);
+      add_feature_link(o, f.properties);
       o.trkseg = [];
       var coords = f.geometry.coordinates;
       var times = options.featureCoordTimes(f);
@@ -160,18 +148,8 @@ function togpx( geojson, options ) {
           var seg = {trkpt: []};
           var i = 0;
           ring.forEach(function(c) {
-            var o = {
-              "@lat": c[1],
-              "@lon":c[0]
-            };
-            if (c[2] !== undefined) {
-              o.ele = c[2];
-            }
-            if (times && times[i]) {
-              o.time = times[i];
-            }
+            seg.trkpt.push(make_wpt(c, times && times[i]));
             i++;
-            seg.trkpt.push(o);
           });
           o.trkseg.push(seg);
         });
@@ -191,8 +169,7 @@ function togpx( geojson, options ) {
       console.log("warning: unsupported geometry type: "+f.geometry.type);
     }
   });
-  gpx_str = JXON.stringify(gpx);
-  return gpx_str;
+  return JXON.stringify(gpx);
 };
 
 module.exports = togpx;

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function togpx( geojson, options ) {
   if (options.metadata)
     gpx.gpx["metadata"] = options.metadata;
   else
-    delete options.metadata;
+    delete gpx.gpx["metadata"];
 
   var features;
   if (geojson.type === "FeatureCollection")

--- a/index.js
+++ b/index.js
@@ -69,8 +69,13 @@ function togpx( geojson, options ) {
     if (coord[2] !== undefined) pt.ele = coord[2];
     if (time) pt.time = time;
     if (props !== undefined) {
-      pt.name = options.featureTitle(props);
-      pt.desc = options.featureDescription(props);
+      ["name", "cmt", "desc", "src", "sym", "type"].forEach(function(k) {
+        if (props[k] !== undefined) pt[k] = props[k];
+      });
+      if (pt.name === undefined)
+        pt.name = options.featureTitle(props);
+      if (pt.desc === undefined)
+        pt.desc = options.featureDescription(props);
       add_feature_link(pt, props);
     }
     return pt;
@@ -107,7 +112,9 @@ function togpx( geojson, options ) {
       var coords = f.geometry.coordinates;
       if (f.geometry.type == "Point") coords = [coords];
       coords.forEach(function(c) {
-        gpx.gpx.wpt.push(make_wpt(c, undefined, f.properties));
+        gpx.gpx.wpt.push(
+          make_wpt(c, f.properties && f.properties.time, f.properties)
+        );
       });
       break;
     // LineStrings

--- a/index.js
+++ b/index.js
@@ -58,7 +58,17 @@ function togpx( geojson, options ) {
     return feature.properties.times || feature.properties.coordTimes || null;
   }
   function add_feature_link(o, props) {
-    if (options.featureLink)
+    if (props && props.links instanceof Array) {
+      o.link = [];
+      props.links.forEach(function(l) {
+        if (l.href !== undefined) {
+          var link = { "@href": l.href };
+          if (l.text !== undefined) link.text = l.text;
+          if (l.type !== undefined) link.type = l.type;
+          o.link.push(link);
+        }
+      });
+    } else if (options.featureLink)
       o.link = { "@href": options.featureLink(props) };
   }
   function make_wpt(coord, time, props) {

--- a/test/test.js
+++ b/test/test.js
@@ -578,6 +578,34 @@ describe("properties", function () {
     expect(wpt.getElementsByTagName("cmt")).to.have.length(1);
     expect(wpt.getElementsByTagName("cmt")[0].textContent).to.equal("comment");
   });
+
+  it('Links', function() {
+    var geojson, result;
+    geojson = {
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        properties: {
+          links: [
+            { href: "http://example.com" },
+            { href: "localhost", text: "link2" }
+          ]
+        },
+        geometry: {
+          type: "Point",
+          coordinates: [0,0]
+        }
+      }]
+    };
+    result = togpx(geojson);
+    result = (new DOMParser()).parseFromString(result, 'text/xml');
+    var links = result.getElementsByTagName("wpt")[0]
+                      .getElementsByTagName("link");
+    expect(links).to.have.length(2);
+    expect(links[0].getAttribute("href")).to.equal("http://example.com");
+    expect(links[1].getAttribute("href")).to.equal("localhost");
+    expect(links[1].getElementsByTagName("text")[0].textContent).to.equal("link2");
+  });
 });
 
 describe("elevation", function () {

--- a/test/test.js
+++ b/test/test.js
@@ -386,8 +386,8 @@ describe("properties", function () {
       features: [{
         type: "Feature",
         properties: {
-          tags: { name: "name" },
-          name: "not_name"
+          tags: { id: "name" },
+          ref: "not_name"
         },
         geometry: {
           type: "Point",
@@ -443,6 +443,13 @@ describe("properties", function () {
     var wpt = result.getElementsByTagName("wpt")[0];
     expect(wpt.getElementsByTagName("desc")).to.have.length(1);
     expect(wpt.getElementsByTagName("desc")[0].textContent).to.equal("p1=foo\np2=bar");
+    // explicitely set description
+    geojson.features[0].properties.desc = "description";
+    result = togpx(geojson);
+    result = (new DOMParser()).parseFromString(result, 'text/xml');
+    wpt = result.getElementsByTagName("wpt")[0];
+    expect(wpt.getElementsByTagName("desc")).to.have.length(1);
+    expect(wpt.getElementsByTagName("desc")[0].textContent).to.equal("description");
   });
 
   it('Description (from tags)', function() {
@@ -548,6 +555,28 @@ describe("properties", function () {
     expect(pts[0].getElementsByTagName("time")[0].textContent).to.equal("2014-06-23T20:29:08Z");
     expect(pts[1].getElementsByTagName("time")).to.have.length(1);
     expect(pts[1].getElementsByTagName("time")[0].textContent).to.equal("2014-06-23T20:29:11Z");
+  });
+
+  it('Comments', function() {
+    var geojson, result;
+    geojson = {
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        properties: {
+          cmt: "comment"
+        },
+        geometry: {
+          type: "Point",
+          coordinates: [1.0,2.0]
+        }
+      }]
+    };
+    result = togpx(geojson);
+    result = (new DOMParser()).parseFromString(result, 'text/xml');
+    var wpt = result.getElementsByTagName("wpt")[0];
+    expect(wpt.getElementsByTagName("cmt")).to.have.length(1);
+    expect(wpt.getElementsByTagName("cmt")[0].textContent).to.equal("comment");
   });
 });
 

--- a/togpx.js
+++ b/togpx.js
@@ -59,7 +59,17 @@ function togpx( geojson, options ) {
     return feature.properties.times || feature.properties.coordTimes || null;
   }
   function add_feature_link(o, props) {
-    if (options.featureLink)
+    if (props && props.links instanceof Array) {
+      o.link = [];
+      props.links.forEach(function(l) {
+        if (l.href !== undefined) {
+          var link = { "@href": l.href };
+          if (l.text !== undefined) link.text = l.text;
+          if (l.type !== undefined) link.type = l.type;
+          o.link.push(link);
+        }
+      });
+    } else if (options.featureLink)
       o.link = { "@href": options.featureLink(props) };
   }
   function make_wpt(coord, time, props) {

--- a/togpx.js
+++ b/togpx.js
@@ -70,8 +70,13 @@ function togpx( geojson, options ) {
     if (coord[2] !== undefined) pt.ele = coord[2];
     if (time) pt.time = time;
     if (props !== undefined) {
-      pt.name = options.featureTitle(props);
-      pt.desc = options.featureDescription(props);
+      ["name", "cmt", "desc", "src", "sym", "type"].forEach(function(k) {
+        if (props[k] !== undefined) pt[k] = props[k];
+      });
+      if (pt.name === undefined)
+        pt.name = options.featureTitle(props);
+      if (pt.desc === undefined)
+        pt.desc = options.featureDescription(props);
       add_feature_link(pt, props);
     }
     return pt;
@@ -108,7 +113,9 @@ function togpx( geojson, options ) {
       var coords = f.geometry.coordinates;
       if (f.geometry.type == "Point") coords = [coords];
       coords.forEach(function(c) {
-        gpx.gpx.wpt.push(make_wpt(c, undefined, f.properties));
+        gpx.gpx.wpt.push(
+          make_wpt(c, f.properties && f.properties.time, f.properties)
+        );
       });
       break;
     // LineStrings

--- a/togpx.js
+++ b/togpx.js
@@ -83,7 +83,7 @@ function togpx( geojson, options ) {
   if (options.metadata)
     gpx.gpx["metadata"] = options.metadata;
   else
-    delete options.metadata;
+    delete gpx.gpx["metadata"];
 
   var features;
   if (geojson.type === "FeatureCollection")


### PR DESCRIPTION
Waypoints (wpt), route points (rtept), and track points (trkpt) share the same type (wptType) in the GPX schema. It makes sense to centralize the code that generates these tags.

Doing so makes it possible to implement more of the supported children. I implemented support for all string based child tags. This is especially nice in conjunction with [mapbox/togeojson](https://github.com/mapbox/togeojson), which reads those tags.