### PR TITLE
times nesting in multilines fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,13 +118,14 @@ function togpx( geojson, options ) {
       var coords = f.geometry.coordinates;
       var times = options.featureCoordTimes(f);
       if (f.geometry.type == "LineString") coords = [coords];
+      if (f.geometry.type == "LineString") times = [times];
       o = {
         "name": options.featureTitle(f.properties),
         "desc": options.featureDescription(f.properties)
       };
       add_feature_link(o,f);
       o.trkseg = [];
-      coords.forEach(function(coordinates) {
+      coords.forEach(function(coordinates, si) {
         var seg = {trkpt: []};
         coordinates.forEach(function(c, i) {
           var o = {
@@ -134,8 +135,8 @@ function togpx( geojson, options ) {
           if (c[2] !== undefined) {
             o.ele = c[2];
           }
-          if (times && times[i]) {
-            o.time = times[i];
+          if (times && times[si][i]) {
+            o.time = times[si][i];
           }
           seg.trkpt.push(o);
         });

--- a/index.js
+++ b/index.js
@@ -135,8 +135,8 @@ function togpx( geojson, options ) {
           if (c[2] !== undefined) {
             o.ele = c[2];
           }
-          if (times && times[si][i]) {
-            o.time = times[si][i];
+          if (times && times[si]) {
+            if (times[si][i]) o.time = times[si][i];
           }
           seg.trkpt.push(o);
         });


### PR DESCRIPTION
Times in nested multiLineStrings are usually nested too (@mapbox/togeojson generates this, for example). It's important to get them in subarrays at each segment.

Example of GeoJSON code needs to be correctly converted:
```
{
	"type": "FeatureCollection",
	"features": [
		{
			"type": "Feature",
			"properties": {
				"coordTimes": [
					[
						"2015-05-08T06:59:14Z",
						"2015-05-08T07:05:34Z"
					],
					[
						"2015-05-08T07:31:29Z",
						"2015-05-08T07:31:38Z",
						"2015-05-08T07:31:39Z"
					]
				]
			},
			"geometry": {
				"type": "MultiLineString",
				"coordinates": [
					[
						[34.4010477327, 44.6769682411, 13.6],
						[34.3997246493, 44.6748953965, 29.46]
					],
					[
						[34.4003802817, 44.6736188326, 18.88],
						[34.4003147352, 44.6734232828, 23.21],
						[34.4003174175, 44.6734021604, 23.69]
					]
				]
			}
		}
	]
}
```