### PR TITLE
Merge of #11 - Allow customisation by transformers

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,12 +94,12 @@ function togpx( geojson, options ) {
   }
   // route point
   function mkRtept(feature, coord, index) {
-    var rtept = assign( mkEntity(feature), mkPoint(feature, coord, index) );
+    var rtept = mkPoint(feature, coord, index);
     return options.transform.rtept && options.transform.rtept(rtept, feature, coord, index) || rtept;
   }
   // track point
   function mkTrkpt(feature, coord, index) {
-    var trkpt = assign( mkEntity(feature), mkPoint(feature, coord, index) );
+    var trkpt = mkPoint(feature, coord, index);
     return options.transform.trkpt && options.transform.trkpt(trkpt, feature, coord, index) || trkpt;
   }
   // route

--- a/index.js
+++ b/index.js
@@ -133,8 +133,8 @@ function togpx( geojson, options ) {
       "@version":"1.1",
       "metadata": null,
       "wpt": [],
-      "trk": [],
-      "rte": []
+      "rte": [],
+      "trk": []
     }
     if (options.creator)
       gpx["@creator"] = options.creator;

--- a/index.js
+++ b/index.js
@@ -2,13 +2,7 @@ var JXON = require("jxon");
 JXON.config({attrPrefix: '@'});
 
 function togpx( geojson, options ) {
-  options = (function (defaults, options) {
-    for (var k in defaults) {
-      if (options.hasOwnProperty(k))
-        defaults[k] = options[k];
-    }
-    return defaults;
-  })({
+  options = assign({
     creator: "togpx",
     metadata: undefined,
     featureTitle: get_feature_title,
@@ -95,17 +89,17 @@ function togpx( geojson, options ) {
   }
   // way point
   function mkWpt(feature, coord, index) {
-    var wpt = defaults( mkEntity(feature), mkPoint(feature, coord, index) );
+    var wpt = assign( mkEntity(feature), mkPoint(feature, coord, index) );
     return options.transform.wpt && options.transform.wpt(wpt, feature, coord, index) || wpt;
   }
   // route point
   function mkRtept(feature, coord, index) {
-    var rtept = defaults( mkEntity(feature), mkPoint(feature, coord, index) );
+    var rtept = assign( mkEntity(feature), mkPoint(feature, coord, index) );
     return options.transform.rtept && options.transform.rtept(rtept, feature, coord, index) || rtept;
   }
   // track point
   function mkTrkpt(feature, coord, index) {
-    var trkpt = defaults( mkEntity(feature), mkPoint(feature, coord, index) );
+    var trkpt = assign( mkEntity(feature), mkPoint(feature, coord, index) );
     return options.transform.trkpt && options.transform.trkpt(trkpt, feature, coord, index) || trkpt;
   }
   // route
@@ -148,6 +142,7 @@ function togpx( geojson, options ) {
       gpx["metadata"] = options.metadata;
     else
       delete options.metadata;
+
     features.forEach(function(f) {
       mapFeature(f, options, gpx);
     });
@@ -196,7 +191,8 @@ function togpx( geojson, options ) {
               "properties": f.properties,
               "geometry": {type: "LineString", coordinates: coords}
             };
-            var recurse_options = defaults({"gpx.trk": false}, options);
+            var recurse_options = assign({}, options);
+            recurse_options = assign(recurse_options, {"gpx.trk": false});
             mapFeature(pseudo_feature, recurse_options, gpx);
           });
         }
@@ -219,7 +215,7 @@ function togpx( geojson, options ) {
     default:
       console.log("warning: unsupported geometry type: "+f.geometry.type);
     }
-  };
+  }
 
   // get features
   var features;
@@ -234,11 +230,11 @@ function togpx( geojson, options ) {
   return JXON.stringify({
     gpx: mkGpx(features)
   });
-};
+}
 
-function defaults(obj1, obj2) {
+function assign(obj1, obj2) {
   for (var attr in obj2)
-    if (!obj1.hasOwnProperty(attr))
+    if (obj2.hasOwnProperty(attr))
       obj1[attr] = obj2[attr];
   return obj1;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -340,6 +340,237 @@ describe("geometries", function () {
   });
 });
 
+describe("routes", function () {
+
+
+  it('LineString (route)', function() {
+    var geojson, options, result;
+    geojson = {
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "LineString",
+          coordinates: [[1.0,2.0],[3.0,4.0]]
+        }
+      }]
+    };
+    options = {
+      "gpx.rte": true,
+      "gpx.trk": false,
+    }
+    result = togpx(geojson, options);
+    result = (new DOMParser()).parseFromString(result, 'text/xml');
+    expect(result.getElementsByTagName("wpt")).to.have.length(0);
+    expect(result.getElementsByTagName("trk")).to.have.length(0);
+    expect(result.getElementsByTagName("rte")).to.have.length(1);
+    var rte = result.getElementsByTagName("rte")[0];
+    var rtepts = rte.getElementsByTagName("rtept");
+    expect(rtepts).to.have.length(2);
+    expect(rtepts[0].getAttribute("lat")).to.eql(2.0);
+    expect(rtepts[0].getAttribute("lon")).to.eql(1.0);
+    expect(rtepts[1].getAttribute("lat")).to.eql(4.0);
+    expect(rtepts[1].getAttribute("lon")).to.eql(3.0);
+  });
+
+  it('MultiLineString (route)', function() {
+    var geojson, options, result;
+    geojson = {
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "MultiLineString",
+          coordinates: [[[1.0,2.0],[3.0,4.0]],[[1.0,1.0],[2.0,2.0]]]
+        }
+      }]
+    };
+    options = {
+      "gpx.rte": true,
+      "gpx.trk": false,
+    }
+    result = togpx(geojson, options);
+    result = (new DOMParser()).parseFromString(result, 'text/xml');
+    expect(result.getElementsByTagName("wpt")).to.have.length(0);
+    expect(result.getElementsByTagName("trk")).to.have.length(0);
+    expect(result.getElementsByTagName("rte")).to.have.length(2);
+    var rtes = result.getElementsByTagName("rte");
+    var rtepts = rtes[0].getElementsByTagName("rtept");
+    expect(rtepts).to.have.length(2);
+    expect(rtepts[0].getAttribute("lat")).to.eql(2.0);
+    expect(rtepts[0].getAttribute("lon")).to.eql(1.0);
+    expect(rtepts[1].getAttribute("lat")).to.eql(4.0);
+    expect(rtepts[1].getAttribute("lon")).to.eql(3.0);
+    rtepts = rtes[1].getElementsByTagName("rtept");
+    expect(rtepts).to.have.length(2);
+    expect(rtepts[0].getAttribute("lat")).to.eql(1.0);
+    expect(rtepts[0].getAttribute("lon")).to.eql(1.0);
+    expect(rtepts[1].getAttribute("lat")).to.eql(2.0);
+    expect(rtepts[1].getAttribute("lon")).to.eql(2.0);
+  });
+
+  it('Polygon (no holes) (route)', function() {
+    var geojson, options, result;
+    geojson = {
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "Polygon",
+          coordinates: [
+            [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ]
+          ]
+        }
+      }]
+    };
+    options = {
+      "gpx.rte": true,
+      "gpx.trk": false,
+    }
+    result = togpx(geojson, options);
+    result = (new DOMParser()).parseFromString(result, 'text/xml');
+    expect(result.getElementsByTagName("wpt")).to.have.length(0);
+    expect(result.getElementsByTagName("trk")).to.have.length(0);
+    expect(result.getElementsByTagName("rte")).to.have.length(1);
+    var rtes = result.getElementsByTagName("rte");
+    expect(rtes).to.have.length(1);
+    var rtepts = rtes[0].getElementsByTagName("rtept");
+    expect(rtepts).to.have.length(5);
+    expect(rtepts[0].getAttribute("lat")).to.eql(0.0);
+    expect(rtepts[0].getAttribute("lon")).to.eql(100.0);
+    // skip remaining points, should be ok
+  });
+
+  it('Polygon (with hole)', function() {
+    var geojson, options, result;
+    geojson = {
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "Polygon",
+          coordinates: [
+            [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ],
+            [ [100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2] ]
+          ]
+        }
+      }]
+    };
+    options = {
+      "gpx.rte": true,
+      "gpx.trk": false,
+    }
+    result = togpx(geojson, options);
+    result = (new DOMParser()).parseFromString(result, 'text/xml');
+    expect(result.getElementsByTagName("wpt")).to.have.length(0);
+    expect(result.getElementsByTagName("trk")).to.have.length(0);
+    expect(result.getElementsByTagName("rte")).to.have.length(2);
+    var rtes = result.getElementsByTagName("rte");
+    expect(rtes).to.have.length(2);
+    var rtepts = rtes[0].getElementsByTagName("rtept");
+    expect(rtepts).to.have.length(5);
+    expect(rtepts[0].getAttribute("lat")).to.eql(0.0);
+    expect(rtepts[0].getAttribute("lon")).to.eql(100.0);
+    // skip remaining points, should be ok
+    rtepts = rtes[1].getElementsByTagName("rtept");
+    expect(rtepts).to.have.length(5);
+    expect(rtepts[0].getAttribute("lat")).to.eql(0.2);
+    expect(rtepts[0].getAttribute("lon")).to.eql(100.2);
+    // skip remaining points, should be ok
+  });
+
+  it('MultiPolygon', function() {
+    var geojson, options, result;
+    geojson = {
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "MultiPolygon",
+          coordinates: [
+            [[[102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0]]],
+            [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]],
+             [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]]
+          ]
+        }
+      }]
+    };
+    options = {
+      "gpx.rte": true,
+      "gpx.trk": false,
+    }
+    result = togpx(geojson, options);
+    result = (new DOMParser()).parseFromString(result, 'text/xml');
+    expect(result.getElementsByTagName("wpt")).to.have.length(0);
+    expect(result.getElementsByTagName("trk")).to.have.length(0);
+    expect(result.getElementsByTagName("rte")).to.have.length(3);
+    var rtes = result.getElementsByTagName("rte");
+    expect(rtes).to.have.length(3);
+    var rtepts = rtes[0].getElementsByTagName("rtept");
+    expect(rtepts).to.have.length(5);
+    expect(rtepts[0].getAttribute("lat")).to.eql(2.0);
+    expect(rtepts[0].getAttribute("lon")).to.eql(102.0);
+    // skip remaining points, should be ok
+    rtepts = rtes[1].getElementsByTagName("rtept");
+    expect(rtepts).to.have.length(5);
+    expect(rtepts[0].getAttribute("lat")).to.eql(0.0);
+    expect(rtepts[0].getAttribute("lon")).to.eql(100.0);
+    // skip remaining points, should be ok
+    rtepts = rtes[2].getElementsByTagName("rtept");
+    expect(rtepts).to.have.length(5);
+    expect(rtepts[0].getAttribute("lat")).to.eql(0.2);
+    expect(rtepts[0].getAttribute("lon")).to.eql(100.2);
+    // skip remaining points, should be ok
+  });
+
+  it('GeometryCollection', function() {
+    var geojson, options, result;
+    geojson = {
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "GeometryCollection",
+          geometries: [
+            { "type": "Point",
+              "coordinates": [100.0, 0.0]
+              },
+            { "type": "LineString",
+              "coordinates": [ [101.0, 0.0], [102.0, 1.0] ]
+              }
+          ]
+        }
+      }]
+    };
+    options = {
+      "gpx.rte": true,
+      "gpx.trk": false,
+    }
+    result = togpx(geojson, options);
+    result = (new DOMParser()).parseFromString(result, 'text/xml');
+    expect(result.getElementsByTagName("wpt")).to.have.length(1);
+    expect(result.getElementsByTagName("trk")).to.have.length(0);
+    expect(result.getElementsByTagName("rte")).to.have.length(1);
+    var wpt = result.getElementsByTagName("wpt")[0];
+    expect(wpt.getAttribute("lat")).to.eql(0.0);
+    expect(wpt.getAttribute("lon")).to.eql(100.0);
+    var rtes = result.getElementsByTagName("rte");
+    expect(rtes).to.have.length(1);
+    var rtepts = rtes[0].getElementsByTagName("rtept");
+    expect(rtepts).to.have.length(2);
+    expect(rtepts[0].getAttribute("lat")).to.eql(0.0);
+    expect(rtepts[0].getAttribute("lon")).to.eql(101.0);
+    expect(rtepts[1].getAttribute("lat")).to.eql(1.0);
+    expect(rtepts[1].getAttribute("lon")).to.eql(102.0);
+  });
+})
+
 describe("properties", function () {
 
   it('Name', function() {
@@ -717,6 +948,41 @@ describe("options", function () {
     var wpt = result.getElementsByTagName("wpt")[0];
     expect(wpt.getElementsByTagName("link")).to.have.length(1);
     expect(wpt.getElementsByTagName("link")[0].getAttribute("href")).to.equal("http://example.com");
+  });
+
+  it('gpx.{wpt|trk|rte}', function() {
+    var geojson, result;
+    geojson = {
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "GeometryCollection",
+          geometries: [
+            { "type": "MultiPoint",
+              "coordinates": [ [31.0, 0.0], [32.0, 0.0] ]
+              },
+            { "type": "MultiLineString",
+              "coordinates": [ [[101.0, 0.0], [102.0, 1.0]], [[103.0, 0.0], [104.0, 1.0]] ]
+              }
+          ]
+        }
+      }]
+    };
+
+    result = togpx(geojson, {
+      "gpx.wpt": true,
+      "gpx.rte": true,
+      "gpx.trk": true,
+    });
+    result = (new DOMParser()).parseFromString(result, 'text/xml');
+    expect(result.getElementsByTagName("wpt")).to.have.length(2);
+    expect(result.getElementsByTagName("trk")).to.have.length(1);
+    expect(result.getElementsByTagName("rte")).to.have.length(2);
+    var trk = result.getElementsByTagName("trk")[0];
+    var trksegs = trk.getElementsByTagName("trkseg");
+    expect(trksegs).to.have.length(2);
   });
 
 });


### PR DESCRIPTION
This is a merge of PR #11 to current master.

From [review comments](https://github.com/tyrasd/togpx/pull/11#issuecomment-221666695):

> 1. rebase the code onto current master and fix the merge conflicts

Done in 5c88fd4.

> the ; is superfluous here, right? (as it's the end of the mapFeature function definition)
> 2. modify the logic in the defaults helper method, so that it matches ES6's Object.assign (just removing the if condition should do the trick), rename it to assign (or so) and use it also override the default options at the very beginning of the code

Done in 95f4bf7, I kept the if condition but reversed the logic to match Object.assign (see e.g. [MDN polyfill](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#polyfill)) and [options init](https://github.com/tyrasd/togpx/blob/ad56b38d393088db4753b9ae2f545dd21c88ebb4/index.js#L7-L8).

I also added two additional changes, to not set feature name, etc. on every trkpt/rtept (46c5e84) and to order rte before trk (4199a90).

> 3. document the new functionality in the project's readme, i.e. the new options (gpx.* flags and transforms) and maybe a dedicated chapter about how to use the transforms with one or two examples.

Still to be done, maybe later, but also wouldn't mind if someone else did.
